### PR TITLE
Fix version detection error on pip installations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ cover
 # Ignore ocp-build-dat
 ocp-build-data/
 tests_functional.log
+
+# Ignore _version.py created by setuptools_scm
+_version.py

--- a/doozerlib/__init__.py
+++ b/doozerlib/__init__.py
@@ -3,15 +3,13 @@ import sys
 if sys.version_info < (3, 8):
     sys.exit('Sorry, Python < 3.8 is not supported.')
 
-from setuptools_scm import get_version
-
-from .runtime import Runtime
-from .pushd import Dir
+from doozerlib.runtime import Runtime
 
 
 def version():
-    return get_version(
-        root=os.path.abspath(
-            os.path.join(os.path.dirname(__file__), '..')
-        )
-    )
+    try:
+        from ._version import version
+    except ImportError:
+        from setuptools_scm import get_version
+        version = get_version()
+    return version

--- a/doozerlib/cli/__main__.py
+++ b/doozerlib/cli/__main__.py
@@ -16,8 +16,8 @@ import urllib
 import pathlib
 
 from future import standard_library
-from doozerlib import Runtime, Dir, cli as cli_package
-from doozerlib import state
+from doozerlib import Runtime, state, cli as cli_package
+from doozerlib.pushd import Dir
 from doozerlib.model import Missing
 from doozerlib.brew import get_watch_task_info_copy
 from doozerlib import metadata

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,9 @@ setup(
     name="rh-doozer",
     author="AOS ART Team",
     author_email="aos-team-art@redhat.com",
-    use_scm_version=True,
+    use_scm_version={
+        'write_to': 'doozerlib/_version.py',
+    },
     setup_requires=['setuptools_scm'],
     description="CLI tool for managing and automating Red Hat software releases",
     long_description=open('README.md').read(),


### PR DESCRIPTION
Fix the following error when invoking `doozer --version` on an installation without the source git repository:

```
LookupError: setuptools-scm was unable to detect version for /usr/local/lib/python3.11/site-packages.
```

Steps to reproduce:

```sh
pip install .

doozer --version
```

This can be solved by introducting setuptools_scm to write a file containing the to-be-installed version.