### PR TITLE
Fix Python 3.11 compatibility

### DIFF
--- a/doozerlib/cli/__init__.py
+++ b/doozerlib/cli/__init__.py
@@ -161,8 +161,6 @@ def click_coroutine(f):
     """ A wrapper to allow to use asyncio with click.
     https://github.com/pallets/click/issues/85
     """
-    f = asyncio.coroutine(f)
-
     def wrapper(*args, **kwargs):
         loop = asyncio.get_event_loop()
         return loop.run_until_complete(f(*args, **kwargs))


### PR DESCRIPTION
`asyncio.coroutine` is no longer needed and removed from Python 3.11.