### PR TITLE
use pull_request_target instead of pull_request

### DIFF
--- a/.github/workflows/snyk_security.yaml
+++ b/.github/workflows/snyk_security.yaml
@@ -1,6 +1,10 @@
 name: Snyk Scan
 
-on: [ push, pull_request ]
+on:
+  push: { }
+  pull_request_target:
+    types: [ opened ]
+    if: github.actor in ['jupierce', 'sosiouxme', 'thiagoalessio', 'joepvd', 'thegreyd', 'vfreex', 'locriandev', 'Ximinhan', 'ashwindasr']
 
 jobs:
   snyk:

--- a/.github/workflows/snyk_security.yaml
+++ b/.github/workflows/snyk_security.yaml
@@ -17,9 +17,11 @@ jobs:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           command: test
+          args: --all-projects
       - name: Test for any known security issues using Static Code Analysis.
         uses: snyk/actions/python-3.8@master
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           command: code test
+          args: --all-projects

--- a/.github/workflows/snyk_security.yaml
+++ b/.github/workflows/snyk_security.yaml
@@ -10,7 +10,7 @@ jobs:
   snyk:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3
       - name: Test for open source vulnerabilities and license issues.
         uses: snyk/actions/python-3.8@master
         env:


### PR DESCRIPTION
GitHub Actions run when a PR is raised, should use the SYNK_TOKEN from the base repo instead of the forked repo. This is achieved by using `pull_request_target` instead of `pull_request` event.  Also making sure that this action runs only for authorized users.