### PR TITLE
Covscan: Fix the command and add RHEL 9 support

### DIFF
--- a/doozerlib/metadata.py
+++ b/doozerlib/metadata.py
@@ -21,7 +21,7 @@ import doozerlib
 from doozerlib import exectools, logutil
 from doozerlib.assembly import assembly_basis_event, assembly_metadata_config
 from doozerlib.brew import BuildStates
-from doozerlib.distgit import ImageDistGitRepo, RPMDistGitRepo
+from doozerlib.distgit import DistGitRepo, ImageDistGitRepo, RPMDistGitRepo
 from doozerlib.model import Missing, Model
 from doozerlib.pushd import Dir
 from doozerlib.util import (isolate_el_version_in_brew_tag,
@@ -224,7 +224,7 @@ class Metadata(object):
             return f'ssh://{self.runtime.user}@{pkgs_host}/{self.qualified_name}'
         return f'ssh://{pkgs_host}/{self.qualified_name}'
 
-    def distgit_repo(self, autoclone=True) -> RPMDistGitRepo:
+    def distgit_repo(self, autoclone=True) -> DistGitRepo:
         if self._distgit_repo is None:
             self._distgit_repo = DISTGIT_TYPES[self.meta_type](self, autoclone=autoclone)
         return self._distgit_repo


### PR DESCRIPTION
- Fixes `images:covscan` command for 4.13. SSL CA certificates are
  currently added too late so we see certificate errors with yum
installs (`rhsm-pulp.corp.redhat.com` is now on HTTPS).
- Fixes missing `cppcheck` package error by adding
  `rhel-8-codeready-builder-rpms` repo.
- Adds support for scanning RHEL 9 based images.
- Adds `--podman-sudo` flag. Unless specified, podman will be run in
  rootless mode so that we will not see files owned by root on Jenkins.
- Adds `--podman-tmpdir` option to customize the directory for image
  downloads. Currently, this directory is a subdirectory of `--result-archive`,
  which might be on an NFS share that doesn't support SELinux labeling
  and cause SELinux issues.