### PR TITLE
[gen_assembly] Fix - Call primitive for model object

### DIFF
--- a/doozerlib/cli/release_gen_assembly.py
+++ b/doozerlib/cli/release_gen_assembly.py
@@ -489,7 +489,7 @@ class GenAssemblyCli:
                 releases_config = self.runtime.get_releases_config()
                 if previous_assembly in releases_config.releases:
                     previous_group = releases_config.releases[previous_assembly].assembly.group
-                    advisories = previous_group.advisories
+                    advisories = previous_group.advisories.primitive()
                     release_jira = previous_group.release_jira
                     self.logger.info(f"Reusing advisories and release ticket from previous candidate assembly {previous_assembly}, {previous_group.advisories}, {previous_group.release_jira}")
                 else:


### PR DESCRIPTION
Bug fix followup to https://github.com/openshift-eng/doozer/pull/760/files
Test run https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/hack/job/ashwin-aos-cd-jobs/job/build%252Fgen-assembly/10/consoleFull (failed because of different reason but fixed the assembly this error)