### PR TITLE
[ART-4558] Use repoquery to detect non-latest rpms

### DIFF
--- a/doozerlib/rhcos.py
+++ b/doozerlib/rhcos.py
@@ -1,8 +1,9 @@
 
+import asyncio
 import json, koji
 from typing import Dict, List, Tuple, Optional
 
-from doozerlib.rpm_utils import parse_nvr
+from doozerlib.rpm_utils import compare_nvr, parse_nvr
 
 from tenacity import retry, stop_after_attempt, wait_fixed
 from urllib import request
@@ -436,11 +437,11 @@ class RHCOSBuildInspector:
 
         raise IOError(f'Unable to determine RHEL version base for rhcos {self.build_id}')
 
-    def find_non_latest_rpms(self) -> List[Tuple[str, str]]:
+    async def find_non_latest_rpms(self) -> List[Tuple[str, str, str]]:
         """
-        If the packages installed in this image overlap packages in the candidate tag,
+        If the packages installed in this image overlap packages in the build repo,
         return NVRs of the latest candidate builds that are not also installed in this image.
-        This indicates that the image has not picked up the latest from candidate.
+        This indicates that the image has not picked up the latest from build repo.
 
         Note that this is completely normal for non-STREAM assemblies. In fact, it is
         normal for any assembly other than the assembly used for nightlies.
@@ -449,33 +450,47 @@ class RHCOSBuildInspector:
         Thus, it is natural for them to lag behind when RPMs change. The should catch
         up with the next RHCOS build.
 
-        :return: Returns a list of Tuple[INSTALLED_NVRs, NEWEST_NVR] where
-        newest is from the "latest" state of the specified candidate tag
-        if same the package installed into this archive is not the same NVR.
+        :return: Returns a list of (installed_rpm, latest_rpm, repo_name)
         """
+        # Find the newest builds in build repos
+        enabled_repos = self.runtime.group_config.rhcos.enabled_repos
+        if not enabled_repos:
+            raise ValueError("RHCOS build repos need to be defined in group config rhcos.enabled_repos.")
+        enabled_repos = enabled_repos.primitive()
+        group_repos = self.runtime.repos
+        tasks = []
+        for repo_name in enabled_repos:
+            repo = group_repos[repo_name]
+            if self.brew_arch in repo.arches:
+                tasks.append(repo.list_rpms(self.brew_arch))
+        # Find the newest rpms for each rpm name among those configured repos
+        candidate_rpms = {}
+        candidate_rpm_repos = {}
+        for repo, rpms in zip(enabled_repos, await asyncio.gather(*tasks)):
+            for rpm in rpms:
+                name = rpm["name"]
+                if name not in candidate_rpms or compare_nvr(rpm, candidate_rpms[name]) > 0:
+                    candidate_rpms[name] = rpm
+                    candidate_rpm_repos[name] = repo
 
-        # Find the default candidate tag appropriate for the RHEL version used by this RHCOS build.
-        candidate_brew_tag = self.runtime.get_default_candidate_brew_tag(el_target=self.get_rhel_base_version())
-
-        # N.B. the "rpms" installed in an image archive are individual RPMs, not brew rpm package builds.
-        # we compare against the individual RPMs from latest candidate rpm package builds.
-        with self.runtime.shared_build_status_detector() as bs_detector:
-            candidate_rpms: Dict[str, Dict] = {
-                # the RPMs are collected by name mainly to de-duplicate (same RPM, multiple arches)
-                rpm['name']: rpm for rpm in
-                bs_detector.find_unshipped_candidate_rpms(candidate_brew_tag, self.runtime.brew_event)
-            }
-
-        old_nvrs: List[Tuple[str, str]] = []
-        # Translate the package builds into a list of individual RPMs. Build dict[rpm_name] -> nvr for every NVR installed
-        # in this RHCOS build.
-        installed_nvr_map: Dict[str, str] = {parse_nvr(installed_nvr)['name']: installed_nvr for installed_nvr in self.get_rpm_nvrs()}
-        # we expect only a few unshipped candidates most of the the time, so we'll just search for those.
-        for name, rpm in candidate_rpms.items():
-            rpm_nvr = rpm['nvr']
-            if name in installed_nvr_map:
-                installed_nvr = installed_nvr_map[name]
-                if rpm_nvr != installed_nvr:
-                    old_nvrs.append((installed_nvr, rpm_nvr))
-
-        return old_nvrs
+        # Compare installed rpms to candidate rpms found from configured repos
+        archive_rpms = {
+            name: {
+                "name": name,
+                "epoch": epoch,
+                "version": version,
+                "release": release,
+                "arch": arch,
+                "nvr": f"{name}-{version}-{release}"
+            } for name, epoch, version, release, arch in self.get_os_metadata_rpm_list()
+        }
+        results: List[Tuple[str, str, str]] = []
+        for name, archive_rpm in archive_rpms.items():
+            candidate_rpm = candidate_rpms.get(name)
+            if not candidate_rpm:
+                continue
+            # For each RPM installed in the image, we want it to match what is in the configured repos
+            # UNLESS the installed NVR is newer than what is in the configured repos.
+            if compare_nvr(archive_rpm, candidate_rpm) < 0:
+                results.append((archive_rpm['nvr'], candidate_rpm['nvr'], candidate_rpm_repos[name]))
+        return results

--- a/tests/test_brew_inspector.py
+++ b/tests/test_brew_inspector.py
@@ -65,7 +65,7 @@ class TestBrewBuildImageInspector(unittest.TestCase):
         self.assertEqual(len(bbii.get_all_archive_dicts()), 5)
         self.assertEqual(len(bbii.get_image_archive_dicts()), 4)  # filters out non-image archive types
 
-        def canned_listRPMs(imageID, *_, **__):
+        def canned_listRPMs(_, imageID, *__, **___):
             return image_archives_list_rpms[imageID]
 
         def canned_getBuild(build_id, *_, **__):

--- a/tests/test_rhcos.py
+++ b/tests/test_rhcos.py
@@ -7,11 +7,12 @@ import unittest
 import os
 import yaml
 from pathlib import Path
-from unittest.mock import patch, MagicMock, Mock
+from unittest.mock import AsyncMock, patch, MagicMock, Mock
 from urllib.error import URLError
 
 from doozerlib import rhcos
-from doozerlib.model import Model
+from doozerlib.model import ListModel, Model
+from doozerlib.repos import Repos
 
 
 class MockRuntime(object):
@@ -31,7 +32,7 @@ def _urlopen_json_cm(mock_urlopen, content, rc=200):
     mock_urlopen.return_value = cm
 
 
-class TestRhcos(unittest.TestCase):
+class TestRhcos(unittest.IsolatedAsyncioTestCase):
 
     def setUp(self):
         self.logger = MagicMock(spec=logging.Logger)
@@ -187,6 +188,63 @@ class TestRhcos(unittest.TestCase):
         container_conf = dict(name='spam', build_metadata_key='eggs')
         with self.assertRaises(rhcos.RhcosMissingContainerException):
             rhcos_build.get_container_pullspec(Model(container_conf))
+
+    @patch('doozerlib.exectools.cmd_assert')
+    @patch('doozerlib.rhcos.RHCOSBuildFinder.rhcos_build_meta')
+    async def test_find_non_latest_rpms_with_missing_enabled_repos(self, rhcos_build_meta_mock, cmd_assert_mock):
+        # mock out the things RHCOSBuildInspector calls in __init__
+        rhcos_meta = {"buildid": "412.86.bogus"}
+        rhcos_commitmeta = {}
+        rhcos_build_meta_mock.side_effect = [rhcos_meta, rhcos_commitmeta]
+        cmd_assert_mock.return_value = ('{"config": {"config": {"Labels": {"version": "412.86.bogus"}}}}', None)
+        pullspecs = {'machine-os-content': 'spam@eggs'}
+        self.runtime.group_config.rhcos = Model({})
+        rhcos_build = rhcos.RHCOSBuildInspector(self.runtime, pullspecs, 's390x')
+        with self.assertRaises(ValueError):
+            await rhcos_build.find_non_latest_rpms()
+
+    @patch('doozerlib.rhcos.RHCOSBuildInspector.get_os_metadata_rpm_list')
+    @patch("doozerlib.repos.Repo.list_rpms")
+    @patch('doozerlib.exectools.cmd_assert')
+    @patch('doozerlib.rhcos.RHCOSBuildFinder.rhcos_build_meta')
+    async def test_find_non_latest_rpms(self, rhcos_build_meta_mock: Mock, cmd_assert_mock: Mock,
+                                        list_rpms: AsyncMock, get_os_metadata_rpm_list: Mock):
+        # mock out the things RHCOSBuildInspector calls in __init__
+        rhcos_meta = {"buildid": "412.86.bogus"}
+        rhcos_commitmeta = {}
+        rhcos_build_meta_mock.side_effect = [rhcos_meta, rhcos_commitmeta]
+        cmd_assert_mock.return_value = ('{"config": {"config": {"Labels": {"version": "412.86.bogus"}}}}', None)
+        pullspecs = {'machine-os-content': 'spam@eggs'}
+        self.runtime.group_config.rhcos = Model({
+            "enabled_repos": ["rhel-8-baseos-rpms", "rhel-8-appstream-rpms"]
+        })
+        repos = Repos(
+            {
+                "rhel-8-baseos-rpms": {"conf": {"baseurl": {"x86_64": "fake_url"}}, "content_set": {"default": "fake"}},
+                "rhel-8-appstream-rpms": {"conf": {"baseurl": {"x86_64": "fake_url"}}, "content_set": {"default": "fake"}},
+                "rhel-8-rt-rpms": {"conf": {"baseurl": {"x86_64": "fake_url"}}, "content_set": {"default": "fake"}},
+            },
+            ["x86_64", "s390x", "ppc64le", "aarch64"]
+        )
+        runtime = MagicMock(
+            repos=repos,
+            group_config=Model({
+                "rhcos": {"enabled_repos": ["rhel-8-baseos-rpms", "rhel-8-appstream-rpms"]}
+            })
+        )
+        list_rpms.return_value = [
+            {'name': 'foo', 'version': '1.0.0', 'release': '1.el9', 'epoch': '0', 'arch': 'x86_64', 'nvr': 'foo-1.0.0-1.el9'},
+            {'name': 'bar', 'version': '1.1.0', 'release': '1.el9', 'epoch': '0', 'arch': 'x86_64', 'nvr': 'bar-1.1.0-1.el9'},
+        ]
+        get_os_metadata_rpm_list.return_value = [
+            ['foo', '0', '1.0.0', '1.el9', 'x86_64'],
+            ['bar', '0', '1.0.0', '1.el9', 'x86_64'],
+        ]
+        rhcos_build = rhcos.RHCOSBuildInspector(runtime, pullspecs, 'x86_64')
+        actual = await rhcos_build.find_non_latest_rpms()
+        list_rpms.assert_awaited()
+        get_os_metadata_rpm_list.assert_called_once_with()
+        self.assertEqual(actual, [('bar-1.0.0-1.el9', 'bar-1.1.0-1.el9', 'rhel-8-baseos-rpms')])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Currently we detect outdated rpms in images and RHCOS by comparing the NVRs of the installed rpms to the NVRs of the rpms in our `rhaos-x.y-rhel-z-candidate` Brew tag.

The current approach has 2 issues. See ART-4558 and ART-3965.

With this new approach, `repoquery` command will be used to query available RPMs in the configured build repos instead of the candidate Brew tag. This will provide more accurate detection and also be able to detect rpms that are not in rhaos repos (e.g. RHEL repos).

Note this PR only covers the `gen-payload` change. A change for `scan-sources` will be another PR.