### PR TITLE
Do not fail jobs when db connection is not alive

### DIFF
--- a/doozerlib/distgit.py
+++ b/doozerlib/distgit.py
@@ -1165,6 +1165,10 @@ class ImageDistGitRepo(DistGitRepo):
         if scratch:
             return
 
+        if not self.runtime.db:
+            self.logger.error('Database connection is not initialized, skipping writing record.')
+            return
+
         with Dir(self.distgit_dir):
             commit_sha = exectools.cmd_assert('git rev-parse HEAD')[0].strip()[:8]
             invoke_ts = str(int(round(time.time() * 1000)))


### PR DESCRIPTION
Should address misreporting:

```
2023-05-16 05:18:20,757 INFO [containers/ingress-node-firewall-daemon] Successfully built image ingress-node-firewall-daemon; task: https://brewweb.engineering.redhat.com/brew/taskinfo?taskID=52624619 ; nvr: ingress-node-firewall-daemon-container-v4.14.0-202305160455.p0.g676211c.assembly.stream ; build record: https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=2504661 
2023-05-16 05:18:20,781 INFO [containers/ingress-node-firewall-daemon] Exception occurred during build:
Traceback (most recent call last):
  File "/mnt/workspace/jenkins/working/aos-cd-builds/build%2Focp4/art-tools/doozer/doozerlib/distgit.py", line 1050, in build_container
    self.update_build_db(True, task_id=task_id, scratch=scratch)
  File "/mnt/workspace/jenkins/working/aos-cd-builds/build%2Focp4/art-tools/doozer/doozerlib/distgit.py", line 1186, in update_build_db
    with self.runtime.db.record('build', metadata=self.metadata):
AttributeError: 'NoneType' object has no attribute 'record'
2023-05-16 05:18:20,781 ERROR [containers/ingress-node-firewall-daemon] Build failure
```