### PR TITLE
[ART-7039] provide client cert to rhsm-pulp

### DIFF
--- a/doozerlib/repos.py
+++ b/doozerlib/repos.py
@@ -412,10 +412,17 @@ class Repos(object):
             'Cache-Control': "no-cache"
         }
 
+        # as of 2023-06-09 authentication is required to validate content sets with rhsm-pulp
+        cs_auth_key = os.environ.get("RHSM_PULP_KEY")
+        cs_auth_cert = os.environ.get("RHSM_PULP_CERT")
+
         retry_count = 4
         for i in range(retry_count):
             try:
-                response = requests.request("POST", url, data=json.dumps(payload), headers=headers)
+                response = requests.request(
+                    "POST", url, data=json.dumps(payload), headers=headers,
+                    cert=(cs_auth_cert, cs_auth_key),
+                )
                 break
             except:
                 if i == retry_count - 1:
@@ -435,8 +442,8 @@ class Repos(object):
     def validate_content_sets(self):
         # Determine repos that have no content sets defined at all; we will give these a pass if nothing tries to use them.
         # This is one reason to accept it if no content_set is defined at all: https://github.com/openshift-eng/ocp-build-data/pull/594
+
         content_set_defined = {}
-        return  # 2023-06-09 workaround until RHELDST-18595 is fulfilled
         for name, repo in self._repos.items():
             content_set_defined[name] = False
             for arch in self._arches + ['default']:

--- a/doozerlib/runtime.py
+++ b/doozerlib/runtime.py
@@ -549,7 +549,11 @@ class Runtime(object):
             self.freeze_automation = self.group_config.freeze_automation or FREEZE_AUTOMATION_NO
 
             if validate_content_sets:
-                self.repos.validate_content_sets()
+                # as of 2023-06-09 authentication is required to validate content sets with rhsm-pulp
+                if not os.environ.get("RHSM_PULP_KEY") or not os.environ.get("RHSM_PULP_CERT"):
+                    self.logger.warn("Missing RHSM_PULP auth, will skip validating content sets")
+                else:
+                    self.repos.validate_content_sets()
 
             if self.group_config.name != self.group:
                 raise IOError(


### PR DESCRIPTION
This cert became a requirement for validating content sets. Arguably we should pull that functionality out of doozer and just validate from the validator, but this is a simpler fix.

The key and cert filenames are provided in two env vars. If they aren't present, then the validation is skipped with a logged warning, so this change should not break anything (and in that case is equivalent to the current "don't validate" workaround).