### PR TITLE
Add a switch for a fast runtime initialization (only group, logging)

### DIFF
--- a/doozerlib/cli/__main__.py
+++ b/doozerlib/cli/__main__.py
@@ -1387,7 +1387,8 @@ CONFIG_RUNTIME_OPTS = {
     'clone_source': False,    # no need, just doing config
     'disabled': True,         # show all, including disabled/wip
     'prevent_cloning': True,  # raise exception is somehow we try to clone
-    'config_only': True       # only initialize config and nothing else
+    'config_only': True,      # only initialize config and nothing else
+    'group_only': False       # only initialize group, logging and nothing else
 }
 
 
@@ -1560,6 +1561,7 @@ def config_read_releases(runtime, as_len, as_yaml, out_file):
     $ doozer --group=openshift-4.13 config:read-releases --yaml --out-file /tmp/out.yaml
     """
 
+    CONFIG_RUNTIME_OPTS['group_only'] = True
     runtime.initialize(**CONFIG_RUNTIME_OPTS)
     content = get_releases(runtime)
 
@@ -1611,6 +1613,7 @@ def config_read_assemblies(runtime, assembly, default, as_len, as_yaml, out_file
     $ doozer --group=openshift-4.13 config:read-assembly --assembly 4.13.2 --yaml assembly.promotion_permits --default []
     """
 
+    CONFIG_RUNTIME_OPTS['group_only'] = True
     runtime.initialize(**CONFIG_RUNTIME_OPTS)
     releases = get_releases(runtime)['releases']
     assembly_data = releases[assembly]

--- a/doozerlib/runtime.py
+++ b/doozerlib/runtime.py
@@ -331,7 +331,7 @@ class Runtime(object):
     def initialize(self, mode='images', clone_distgits=True,
                    validate_content_sets=False,
                    no_group=False, clone_source=None, disabled=None,
-                   prevent_cloning: bool = False, config_only: bool = False):
+                   prevent_cloning: bool = False, config_only: bool = False, group_only: bool = False):
 
         if self.initialized:
             return
@@ -412,6 +412,9 @@ class Runtime(object):
             self.group, self.group_commitish = self.group.split('@', 1)
         else:
             self.group_commitish = self.group
+
+        if group_only:
+            return
 
         # For each "--stream alias image" on the command line, register its existence with
         # the runtime.


### PR DESCRIPTION
For fast operations like `doozer config:read-releases` or `doozer config:read-assembly` we only need logging, group config and very little more. This is a proposal to add a switch (disabled by default) to return from `Runtime.initialize` right after these minimal pieces are initialized.