### PR TITLE
Move parallel_exec() to exectools; keep only one version

### DIFF
--- a/doozerlib/cli/detect_embargo.py
+++ b/doozerlib/cli/detect_embargo.py
@@ -178,8 +178,8 @@ def detect_embargoes_in_pullspecs(runtime: Runtime, pullspecs: List[str]):
     :return: list of Brew build dicts that have embargoed fixes
     """
     runtime.logger.info(f"Fetching manifests for {len(pullspecs)} pullspecs...")
-    jobs = runtime.parallel_exec(lambda pullspec, _: get_nvr_by_pullspec(pullspec), pullspecs,
-                                 min(len(pullspecs), multiprocessing.cpu_count() * 4, 32))
+    jobs = exectools.parallel_exec(lambda pullspec, _: get_nvr_by_pullspec(pullspec), pullspecs,
+                                   min(len(pullspecs), multiprocessing.cpu_count() * 4, 32))
     nvrs = jobs.get()
     suspect_nvrs = []
     suspect_pullspecs = []
@@ -205,7 +205,7 @@ def detect_embargoes_in_releases(runtime: Runtime, pullspecs: List[str]):
     """
     runtime.logger.info(f"Fetching component pullspecs from {len(pullspecs)} release payloads...")
     ignore_rhcos_tags = rhcos.get_container_names(runtime)
-    jobs = runtime.parallel_exec(
+    jobs = exectools.parallel_exec(
         lambda pullspec, _: get_image_pullspecs_from_release_payload(pullspec, ignore_rhcos_tags),
         pullspecs,
         min(len(pullspecs), multiprocessing.cpu_count() * 4, 32)

--- a/doozerlib/cli/scan_sources.py
+++ b/doozerlib/cli/scan_sources.py
@@ -169,7 +169,7 @@ def config_scan_source_changes(runtime: Runtime, ci_kubeconfig, as_yaml):
                 add_image_meta_change(image_meta, RebuildHint(RebuildHintCode.CONFIG_CHANGE, 'Unable to retrieve config_digest'))
 
     runtime.logger.debug(f'Will be assessing tagging changes between newest_image_event_ts:{newest_image_event_ts} and oldest_image_event_ts:{oldest_image_event_ts}')
-    change_results = runtime.parallel_exec(
+    change_results = exectools.parallel_exec(
         f=lambda image_meta, terminate_event: image_meta.does_image_need_change(changing_rpm_packages, image_meta.build_root_tag(), newest_image_event_ts, oldest_image_event_ts),
         args=runtime.image_metas(),
         n_threads=20

--- a/doozerlib/exceptions.py
+++ b/doozerlib/exceptions.py
@@ -2,7 +2,26 @@
 avoid circular imports
 """
 
+import sys
+import traceback
+
+from future.utils import as_native_str
+
 
 class DoozerFatalError(Exception):
     """A broad exception for errors during Brew CRUD operations"""
     pass
+
+
+class WrapException(Exception):
+    """ https://bugs.python.org/issue13831 """
+    def __init__(self):
+        super(WrapException, self).__init__()
+        exc_type, exc_value, exc_tb = sys.exc_info()
+        self.exception = exc_value
+        self.formatted = "".join(
+            traceback.format_exception(exc_type, exc_value, exc_tb))
+
+    @as_native_str()
+    def __str__(self):
+        return "{}\nOriginal traceback:\n{}".format(Exception.__str__(self), self.formatted)

--- a/doozerlib/image.py
+++ b/doozerlib/image.py
@@ -441,8 +441,9 @@ class ImageMetadata(Metadata):
         # server since no result has yet been returned. Shuffling the installed package list spreads the threads
         # out among the packages to reduce re-work by the server.
         random.shuffle(installed_builds)
-        changes_res = runtime.parallel_exec(
-            f=lambda installed_package_build, terminate_event: is_image_older_than_package_build_tagging(self, image_build_event_id, installed_package_build, newest_image_event_ts, oldest_image_event_ts),
+        changes_res = exectools.parallel_exec(
+            f=lambda installed_package_build, terminate_event: is_image_older_than_package_build_tagging(
+                self, image_build_event_id, installed_package_build, newest_image_event_ts, oldest_image_event_ts),
             args=installed_builds,
             n_threads=10
         )

--- a/tests/test_exectools.py
+++ b/tests/test_exectools.py
@@ -229,6 +229,14 @@ class TestGather(IsolatedAsyncioTestCase):
             self.assertEqual(out, "fake_stdout")
             self.assertEqual(err, "fake_stderr")
 
+    def test_parallel_exec(self):
+        items = [1, 2, 3]
+        results = exectools.parallel_exec(
+            lambda k, v: k,
+            items, n_threads=4)
+        results = results.get()
+        self.assertEqual(results, items)
+
 
 if __name__ == "__main__":
 

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -17,18 +17,6 @@ def stub_runtime():
 
 
 class RuntimeTestCase(unittest.TestCase):
-    def test_parallel_exec(self):
-        ret = runtime.Runtime._parallel_exec(lambda x: x * 2, range(5), n_threads=20)
-        self.assertEqual(ret, [0, 2, 4, 6, 8])
-
-    def test_parallel_exec2(self):
-        items = [1, 2, 3]
-        results = stub_runtime().parallel_exec(
-            lambda k, v: k,
-            items, n_threads=4)
-        results = results.get()
-        self.assertEqual(results, items)
-
     def test_get_remote_branch_ref(self):
         rt = stub_runtime()
         flexmock(exectools).should_receive("cmd_assert").once().and_return("spam", "")


### PR DESCRIPTION
We have 2 similar functions that are used to execute a given function in a thread pool, with a predefined set of params. These functions are both defined in `runtime.Runtime`. This PR aims to clean up the code by keeping just one version of `parallel_exec`; moreover, the natural place for such a function is probably within `exectools` module.

Tested in a hack space with `ocp4-scan`, that calls `doozer config:scan-sources` and `parallel_exec`: https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/hack/job/dpaolell/job/ocp4-scan/94/console