### PR TITLE
Create microshift advisory placeholder for 4.12+

### DIFF
--- a/doozerlib/cli/release_gen_assembly.py
+++ b/doozerlib/cli/release_gen_assembly.py
@@ -476,6 +476,12 @@ class GenAssemblyCli:
             'extras': -1,
             'metadata': -1,
         }
+
+        # For OCP >= 4.12, also microshift advisory placeholder must be created
+        major, minor = self.runtime.get_major_minor_fields()
+        if major > 4 or minor >= 12:  # exclude 3.11, include any 5.y and 4.12+
+            advisories['microshift'] = -1
+
         release_jira = "ART-0"
 
         if self.assembly_type == AssemblyTypes.CANDIDATE:

--- a/tests/cli/test_gen_assembly.py
+++ b/tests/cli/test_gen_assembly.py
@@ -272,6 +272,7 @@ class TestGenPayloadCli(TestCase):
 
     def test_get_advisories_release_jira_default(self):
         runtime = MagicMock()
+        runtime.get_major_minor_fields.return_value = (4, 11)
         gacli = GenAssemblyCli(runtime=runtime, gen_assembly_name='4.11.2')
         advisories, release_jira = gacli._get_advisories_release_jira()
         self.assertEqual(advisories, {
@@ -282,6 +283,17 @@ class TestGenPayloadCli(TestCase):
         })
         self.assertEqual(release_jira, "ART-0")
 
+        runtime.get_major_minor_fields.return_value = (4, 12)
+        gacli = GenAssemblyCli(runtime=runtime, gen_assembly_name='4.12.2')
+        advisories, release_jira = gacli._get_advisories_release_jira()
+        self.assertEqual(advisories, {
+            'image': -1,
+            'rpm': -1,
+            'extras': -1,
+            'metadata': -1,
+            'microshift': -1,
+        })
+
     def test_get_advisories_release_jira_candidate_reuse(self):
         runtime = MagicMock()
         advisories = {'image': 123, 'rpm': 456, 'extras': 789, 'metadata': 654}
@@ -290,6 +302,7 @@ class TestGenPayloadCli(TestCase):
             'advisories': advisories,
             'release_jira': release_jira
         }}}}})
+        runtime.get_major_minor_fields.return_value = (4, 12)
         gacli = GenAssemblyCli(runtime=runtime, gen_assembly_name='rc.1')
         actual = gacli._get_advisories_release_jira()
         self.assertEqual(advisories, actual[0])

--- a/tests/cli/test_gen_assembly.py
+++ b/tests/cli/test_gen_assembly.py
@@ -294,6 +294,27 @@ class TestGenPayloadCli(TestCase):
             'microshift': -1,
         })
 
+        runtime.get_major_minor_fields.return_value = (3, 11)
+        gacli = GenAssemblyCli(runtime=runtime, gen_assembly_name='3.11.2')
+        advisories, release_jira = gacli._get_advisories_release_jira()
+        self.assertEqual(advisories, {
+            'image': -1,
+            'rpm': -1,
+            'extras': -1,
+            'metadata': -1,
+        })
+
+        runtime.get_major_minor_fields.return_value = (5, 1)
+        gacli = GenAssemblyCli(runtime=runtime, gen_assembly_name='5.1.12')
+        advisories, release_jira = gacli._get_advisories_release_jira()
+        self.assertEqual(advisories, {
+            'image': -1,
+            'rpm': -1,
+            'extras': -1,
+            'metadata': -1,
+            'microshift': -1,
+        })
+
     def test_get_advisories_release_jira_candidate_reuse(self):
         runtime = MagicMock()
         advisories = {'image': 123, 'rpm': 456, 'extras': 789, 'metadata': 654}


### PR DESCRIPTION
Ref. https://issues.redhat.com/browse/ART-6666

[4.11 test run](https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/hack/job/dpaolell/job/gen-assembly/5/console): no microshift advisory

[4.12 test run](https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/hack/job/dpaolell/job/gen-assembly/7/console): microshift advisory placeholder created