### PR TITLE
Add doozer config:read-rpms

### DIFF
--- a/doozerlib/cli/__main__.py
+++ b/doozerlib/cli/__main__.py
@@ -37,6 +37,7 @@ from doozerlib.cli.images_streams import images_streams, images_streams_mirror, 
 from doozerlib.cli.release_gen_assembly import releases_gen_assembly, gen_assembly_from_releases
 from doozerlib.cli.scan_sources import config_scan_source_changes
 from doozerlib.cli.rpms_build import rpms_build
+from doozerlib.cli.rpms_read_config import config_read_rpms
 from doozerlib.cli.config_plashet import config_plashet
 from doozerlib.cli.release_calc_upgrade_tests import release_calc_upgrade_tests
 from doozerlib.cli.inspect_stream import inspect_stream

--- a/doozerlib/cli/rpms_read_config.py
+++ b/doozerlib/cli/rpms_read_config.py
@@ -1,0 +1,21 @@
+import json
+
+import yaml
+import click
+
+from doozerlib.cli import cli
+from doozerlib.cli import pass_runtime
+from doozerlib.runtime import Runtime
+
+
+@cli.command('config:read-rpms', help="Prints the configuration for the RPMS provided by --rpms.")
+@click.option('--yaml', 'as_yaml', required=False, default=False, is_flag=True, help='Format the output as yaml')
+@pass_runtime
+def config_read_rpms(runtime: Runtime, as_yaml: bool):
+    runtime.initialize(mode='rpms', clone_source=False, clone_distgits=False)
+    config = runtime.get_rpm_config()
+
+    if as_yaml:
+        click.echo(yaml.safe_dump(yaml.safe_load((json.dumps(config)))))
+    else:
+        click.echo(json.dumps(config, indent=4))

--- a/doozerlib/rpmcfg.py
+++ b/doozerlib/rpmcfg.py
@@ -1,6 +1,5 @@
 import glob
 import io
-import json
 import os
 import threading
 from typing import Optional

--- a/doozerlib/rpmcfg.py
+++ b/doozerlib/rpmcfg.py
@@ -1,5 +1,6 @@
 import glob
 import io
+import json
 import os
 import threading
 from typing import Optional

--- a/doozerlib/runtime.py
+++ b/doozerlib/runtime.py
@@ -1586,3 +1586,9 @@ class Runtime(object):
         self.gitdata = gitdata.GitData(data_path=self.data_path, clone_dir=self.working_dir,
                                        commitish=self.group_commitish, reclone=self.upcycle, logger=self.logger)
         self.data_dir = self.gitdata.data_dir
+
+    def get_rpm_config(self) -> dict:
+        config = {}
+        for key, val in self.rpm_map.items():
+            config[key] = val.raw_config
+        return config


### PR DESCRIPTION
Ref. https://issues.redhat.com/browse/ART-6671

We need an easy way to read an RPM config and determine its characteristics. In this case, we need `arches` for microshift-sync

Example usage:
```
doozer --group=openshift-4.14 -r microshift rpms:read-config --yaml 
```