### PR TITLE
Fix parallel_exec invocation

### DIFF
--- a/doozerlib/runtime.py
+++ b/doozerlib/runtime.py
@@ -1495,7 +1495,7 @@ class Runtime(object):
             if n_threads is None:
                 n_threads = self.global_opts['distgit_threads']
             return exectools.parallel_exec(
-                lambda m: m.distgit_repo(),
+                lambda m, _: m.distgit_repo(),
                 self.all_metas(),
                 n_threads=n_threads).get()
 
@@ -1505,7 +1505,7 @@ class Runtime(object):
         if n_threads is None:
             n_threads = self.global_opts['distgit_threads']
         return exectools.parallel_exec(
-            lambda m: m.distgit_repo().push(),
+            lambda m, _: m.distgit_repo().push(),
             self.all_metas(),
             n_threads=n_threads).get()
 


### PR DESCRIPTION
With https://github.com/openshift-eng/doozer/pull/791, we kept only the `parallel_exec` invocation that passes `terminate_event` arg to the callable. Places that used the alternate version (with no event arg being forwarded) needed an arg placeholder in their lambda signature.

Tested with:
```
doozer --assembly=stream --group 'openshift-4.7' --latest-parent-version --images kube-rbac-proxy images:rebase --version v4.7 --release '202307061519.p?' --message 'Updating Dockerfile version and release v4.7-202307061519.p?' --no-push
```