### PR TITLE
Use git+https

### DIFF
--- a/doozerlib/constants.py
+++ b/doozerlib/constants.py
@@ -8,7 +8,7 @@ GIT_NO_PROMPTS = {
 
 GITHUB_TOKEN = "GITHUB_TOKEN"
 BREWWEB_URL = "https://brewweb.engineering.redhat.com/brew"
-DISTGIT_GIT_URL = "https://pkgs.devel.redhat.com/git"
+DISTGIT_GIT_URL = "git+https://pkgs.devel.redhat.com/git"
 
 # Environment variables that should be set for doozer interaction with db for storing and retrieving build records.
 # DB ENV VARS


### PR DESCRIPTION
https://github.com/openshift-eng/doozer/pull/789 broke ocp4:

```
GenericError: Invalid scheme in scm url. Valid schemes are: cvs+ssh:// cvs:// git+http:// git+https:// git+rsync:// git+ssh:// git:// svn+http:// svn+https:// svn+ssh:// svn://
```

seen for example [here](https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/hack/job/dpaolell/job/ocp4/157/console)


This PR sets the protocol to `git+https`. Successful ocp4 run: https://saml.buildvm.hosts.prod.psi.bos.redhat.com:8888/job/hack/job/dpaolell/job/ocp4/160/console