### PR TITLE
[config:read-releases] Fetch exact branch

### DIFF
--- a/doozerlib/cli/__main__.py
+++ b/doozerlib/cli/__main__.py
@@ -1533,22 +1533,10 @@ def get_releases(runtime) -> dict:
         raise DoozerFatalError('A GITHUB_TOKEN environment variable must be defined!')
     github_token = os.environ['GITHUB_TOKEN']
 
+    # TODO: data_path can be a local path in which case this will fail
     owner = runtime.data_path.split('/')[-2]
     api = GhApi(owner=owner, repo='ocp-build-data', token=github_token)
-    commitish = runtime.group_commitish
-
-    # TODO: this assumes commitish is a branch it doesn't work for tags/shasum. fix it
-    # api.git.get_ref(shasum) doesn't work
-    ref = api.git.get_ref(f'heads/{commitish}')
-    tree = api.git.get_tree(ref.object.sha).tree
-    releases_file, releases_yaml = 'releases.yml', None
-    for f in tree:
-        if f.path == releases_file:
-            releases_yaml = f
-    if not releases_yaml:
-        raise DoozerFatalError(f'Cannot find {releases_file} in {runtime.group_commitish}')
-
-    blob = api.git.get_blob(file_sha=releases_yaml['sha'])
+    blob = api.repos.get_content('releases.yml', ref=runtime.group_commitish)
     return yaml.safe_load(base64.b64decode(blob['content']))
 
 


### PR DESCRIPTION
We're using ghapi's list_files method which calls [get_branch]( https://github.com/fastai/ghapi/blob/d2ac97ecf676d1a2f86fb14b0d0c1a48193de510/ghapi/core.py#L224)
which fetches the first matched branch with given prefix (!!)
So in my case when I pointed doozer to my fork and said fetch me openshift-4.7, 
it returned "openshift-4.7-cachito" branch.

This is pretty alarming behavior, so let's not use methods that depend on get_branch()

## Test
(I had to delete the openshift-4.7-cachito branch to unblock my failing job, but 
the original behavior should be reproducible)
- `doozer --data-path=https://github.com/thegreyd/ocp-build-data --group=openshift-4.14@disable_ptp config:read-releases --yaml`