### PR TITLE
remove setuptools-sm for art-tools merger

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,6 @@ pydantic ~= 1.10.7
 python-dateutil >= 2.8.1
 openshift-client >= 1.0.12
 ruamel.yaml
-setuptools-scm
 setuptools>=65.5.1 # not directly required, pinned by Snyk to avoid a vulnerability
 aiohttp
 jira==3.4.1

--- a/setup.py
+++ b/setup.py
@@ -12,10 +12,7 @@ setup(
     name="rh-doozer",
     author="AOS ART Team",
     author_email="aos-team-art@redhat.com",
-    use_scm_version={
-        'write_to': 'doozerlib/_version.py',
-    },
-    setup_requires=['setuptools_scm'],
+    setup_requires=[],
     description="CLI tool for managing and automating Red Hat software releases",
     long_description=open('README.md').read(),
     url="https://github.com/openshift-eng/doozer",


### PR DESCRIPTION
When we do pip install for doozer in merged art-tools repo, setuptools requires it to be a git repo (submodule), which doozer will no longer be.