### PR TITLE
rpms:rebase: Pass some env vars to modification scripts

### DIFF
--- a/doozerlib/rpmcfg.py
+++ b/doozerlib/rpmcfg.py
@@ -111,7 +111,11 @@ class RPMMetadata(Metadata):
             "component_name": self.name,
             "kind": "spec",
             "content": new_specfile_data,
-            "set_env": {"PATH": path},
+            "set_env": {
+                "PATH": path,
+                "BREW_EVENT": f'{self.runtime.brew_event}',
+                "BREW_TAG": f'{self.candidate_brew_tag()}'
+            },
             "runtime_assembly": self.runtime.assembly,
             "release_name": "",
         }


### PR DESCRIPTION
Those environment variables are available to image build but not rpm build. Now they are required to support
https://github.com/openshift-eng/ocp-build-data/pull/3184.