### PR TITLE
Inspect assembly rhcos

### DIFF
--- a/doozerlib/cli/__main__.py
+++ b/doozerlib/cli/__main__.py
@@ -29,6 +29,7 @@ from doozerlib import metadata
 from doozerlib.config import MetaDataConfig as mdc
 from doozerlib.cli import cli, pass_runtime, validate_semver_major_minor_patch
 
+from doozerlib.cli.release_gen_payload import assembly_rhcos_cli
 from doozerlib.cli.release_gen_payload import release_gen_payload
 from doozerlib.cli.get_nightlies import get_nightlies
 from doozerlib.cli.detect_embargo import detect_embargo

--- a/doozerlib/cli/__main__.py
+++ b/doozerlib/cli/__main__.py
@@ -29,7 +29,7 @@ from doozerlib import metadata
 from doozerlib.config import MetaDataConfig as mdc
 from doozerlib.cli import cli, pass_runtime, validate_semver_major_minor_patch
 
-from doozerlib.cli.release_gen_payload import assembly_rhcos_cli
+from doozerlib.cli.release_gen_payload import inspect_assembly_rhcos_cli
 from doozerlib.cli.release_gen_payload import release_gen_payload
 from doozerlib.cli.get_nightlies import get_nightlies
 from doozerlib.cli.detect_embargo import detect_embargo

--- a/doozerlib/cli/release_gen_payload.py
+++ b/doozerlib/cli/release_gen_payload.py
@@ -30,6 +30,7 @@ from doozerlib.model import Model
 from doozerlib.exceptions import DoozerFatalError
 from doozerlib.util import find_manifest_list_sha
 
+
 @cli.command("inspect-assembly:rhcos")
 @pass_runtime
 def inspect_assembly_rhcos_cli(runtime):
@@ -47,6 +48,7 @@ def inspect_assembly_rhcos_cli(runtime):
     if len(rhcos_build_ids) > len(runtime.arches):
         raise ValueError("Not all payload tags have the same rhcos build, command does not support that usecase")
     click.echo(sorted(rhcos_build_ids))
+
 
 @cli.command("release:gen-payload", short_help="Mirror release images to quay and release-controller")
 @click.option("--is-name", metavar="NAME", required=False,


### PR DESCRIPTION
As part of https://issues.redhat.com/browse/ART-2892
we need to find rhcos build id for any given assembly/brew-event, 
at prepare time.

Elliott right now does not have the ability to compute assembly 
payload entries, and so we will use this to output the buildID(s) and then 
let elliott use it

`doozer -g openshift-4.13 --assembly 4.13.5 inspect-assembly:rhcos`
