### PR TITLE
Remove jenkins unit test run

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,24 +9,6 @@ pipeline {
         }
     }
     stages {
-        stage("Tests & Coverage") {
-            steps {
-                script {
-                    catchError(stageResult: 'FAILURE') {
-                        // Rebuild tox environment after change requirements. https://github.com/openshift/elliott/pull/149
-                        sh """
-                            tox_args="\$(git diff --name-only HEAD~5 | grep -Fxq -e requirements.txt -e requirements-dev.txt -e MANIFEST.in -e setup.py && echo '--recreate' || true)"
-                            tox \$tox_args > results.txt 2>&1
-                        """
-                    }
-                    results = readFile("results.txt").trim()
-                    echo results
-                    if (env.CHANGE_ID) {
-                        commentOnPullRequest(msg: "### Build <span>#</span>${env.BUILD_NUMBER}\n```\n${results}\n```")
-                    }
-                }
-            }
-        }
         stage("Publish Coverage Report") {
             steps {
                 catchError(buildResult: 'UNSTABLE', stageResult: 'FAILURE') {


### PR DESCRIPTION
Now that we have unit test running in https://github.com/openshift-eng/doozer/actions 
for every PR (and being reported inline) - remove CI unit test run