### PR TITLE
remove deprecated module

### DIFF
--- a/tests/test_rpm_utils.py
+++ b/tests/test_rpm_utils.py
@@ -1,4 +1,3 @@
-import imp
 from unittest import TestCase
 from doozerlib import rpm_utils
 


### PR DESCRIPTION
the imp module is deprecated and not used
find in test results of https://github.com/openshift-eng/doozer/actions/runs/5760509829/job/15616596716?pr=814